### PR TITLE
Attempt to turn on artifact building.

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -128,7 +128,7 @@ jobs:
       shell: bash
 
     - uses: actions/upload-artifact@v3
-      if: matrix.name == 'windows-msvc'
+      if: matrix.name == 'windows-msvc-hunter'
       with:
         name: 'assimp-bins-${{ matrix.name }}-${{ github.sha }}'
         path: build/bin


### PR DESCRIPTION
This commit turns on artifact uploads for the msvc build. This would allow folks to easily download a copy of the windows qt assimp viewer without needing to build assimp themselves, which can really aid in debugging on various systems. Thanks!